### PR TITLE
Fix missing sys/sysmacro includes.

### DIFF
--- a/lib/libv4lconvert/control/libv4lcontrol.c
+++ b/lib/libv4lconvert/control/libv4lcontrol.c
@@ -20,9 +20,7 @@
  */
 
 #include <sys/types.h>
-#if defined(MAJOR_IN_SYSMACROS)
 #include <sys/sysmacros.h>
-#endif
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/lib/libv4lconvert/libv4lconvert.c
+++ b/lib/libv4lconvert/libv4lconvert.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include "libv4lconvert.h"
 #include "libv4lconvert-priv.h"
 #include "libv4lsyscall-priv.h"

--- a/utils/v4l2-ctl/v4l2-ctl.cpp
+++ b/utils/v4l2-ctl/v4l2-ctl.cpp
@@ -28,6 +28,7 @@
 #include <getopt.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
Without them, `make` didn't succeed with linker error "undefined reference to 'minor'".

On Ubuntu 19.10, following the build instructions
```
	./bootstrap.sh
	./configure
	make
```
leads to the linker error:
```
  CXXLD    v4l2-compliance
/usr/bin/ld: ../../lib/libv4lconvert/.libs/libv4lconvert.so: undefined reference to `minor'
collect2: error: ld returned 1 exit status
```
Adding the missing includes fixes that.